### PR TITLE
Two values calibration

### DIFF
--- a/app/src/main/java/org/woheller69/level/Level.java
+++ b/app/src/main/java/org/woheller69/level/Level.java
@@ -179,9 +179,17 @@ public class Level extends AppCompatActivity implements OrientationListener {
     }
 
     @Override
-    public void onCalibrationSaved(boolean success) {
-        Toast.makeText(this, success ?
-                        R.string.calibrate_saved : R.string.calibrate_failed,
-                Toast.LENGTH_LONG).show();
+    public void onCalibrationSaved(boolean success, int ccount) {
+        if (success) {
+            if (ccount < 2) {
+              Toast.makeText(this,R.string.calibrate_first_step,Toast.LENGTH_LONG).show();
+            }
+            else {
+              Toast.makeText(this,R.string.calibrate_saved,Toast.LENGTH_LONG).show();
+            }
+        }
+        else {
+            Toast.makeText(this, R.string.calibrate_failed, Toast.LENGTH_LONG).show();
+        }
     }
 }

--- a/app/src/main/java/org/woheller69/level/orientation/OrientationListener.java
+++ b/app/src/main/java/org/woheller69/level/orientation/OrientationListener.java
@@ -23,7 +23,7 @@ public interface OrientationListener {
 
     void onOrientationChanged(Orientation orientation, float pitch, float roll, float balance);
 
-    void onCalibrationSaved(boolean success);
+    void onCalibrationSaved(boolean success, int ccount);
 
     void onCalibrationReset(boolean success);
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="name">Bubble</string>
+    <string name="name">Wasserwaage</string>
     <string name="reset">Zurücksetzen</string>
     <string name="not_supported">Ausrichtung nicht unterstützt</string>
     <string name="calibrate">Kalibrieren</string>
     <string name="calibrate_info">Drücke MENU zum Kalibrieren...</string>
     <string name="calibrate_title">Das Gerät kalibrieren</string>
     <string name="calibrate_message">Lege die Seite des Telefons zum Kalibrieren auf eine flache horizontale Oberfläche und drücke die Schaltfläche Kalibrieren.</string>
-    <string name="calibrate_saved">Kalibrierung erfolgreich!</string>
+    <string name="calibrate_first_step">Bitte das Gerät nun um 180 Grad wenden und nochmals kalibrieren!</string>
+    <string name="calibrate_saved">Kalibrierung erfolgreich fertiggestellt!</string>
     <string name="calibrate_failed">Kalibrierung fehlgeschlagen!</string>
     <string name="calibrate_restored">Originale Kalibrierung wiederhergestellt!</string>
     <string name="preferences">Einstellungen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7,6 +7,7 @@
     <string name="calibrate_info">pulse MENU para calibrar...</string>
     <string name="calibrate_title">Calibrar el teléfono</string>
     <string name="calibrate_message">Pon el lado del teléfono que desea calibrar sobre una superficie plana horizontal y pulse el botón Calibrar.</string>
+    <string name="calibrate_first_step">Ahora gira el dispositivo 180 grados y vuelve a calibrarlo!</string>
     <string name="calibrate_saved">Calibración personalizada salvado !</string>
     <string name="calibrate_failed">Error de calibración !</string>
     <string name="calibrate_restored">Calibración original restaurada !</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -7,6 +7,7 @@
     <string name="calibrate_info">sakatu MENU kalibratzeko...</string>
     <string name="calibrate_title">Kalibratu zure telefonoa</string>
     <string name="calibrate_message">Jarri zure Android gailuaren edozein alde (atzekoa barne) gainazal horizontal lau batean eta sakatu Kalibratu botoia.\n\nEdo berrezarri kalibrazioa telefonoaren alde guztientzat.</string>
+    <string name="calibrate_first_step"> Orain aktibatu gailua 180 gradu eta kalibratu berriro!!</string>
     <string name="calibrate_saved">Kalibrazio pertsonalizatua gordeta!</string>
     <string name="calibrate_failed">Kalibrazioak huts egind du!</string>
     <string name="calibrate_restored">Jatorrizko kalibrazioa leheneratuta!</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -7,6 +7,7 @@
     <string name="calibrate_info">appuyez sur MENU pour étalonner...</string>
     <string name="calibrate_title">Etalonnage du téléphone</string>
     <string name="calibrate_message">Posez le côté du téléphone que vous souhaitez calibrer sur une surface horizontale et plane de référence puis appuyez sur le bouton Etalonner.\n\nOu réinitialisez l\'étalonnage pour l\'ensemble des côtés du téléphone.</string>
+    <string name="calibrate_first_step">Maintenant, tournez votre appareil de 180 degrés et calibrez à nouveau!</string>
     <string name="calibrate_saved">Etalonnage sauvegardé !</string>
     <string name="calibrate_failed">L\'étalonnage a échoué !</string>
     <string name="calibrate_restored">Etalonnage d\'usine restauré !</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -7,6 +7,7 @@
     <string name="calibrate_info">Premere MENU per calibrare...</string>
     <string name="calibrate_title">Calibrare il telefono</string>
     <string name="calibrate_message">Posto il lato del telefono che si desidera calibrare su una superficie piana orizzontale e premere il pulsante di calibrazione.</string>
+    <string name="calibrate_first_step">Ora ruotate il vostro dispositivo di 180 gradi e calibrate di nuovo!</string>
     <string name="calibrate_saved">Calibrazione personalizzata salvata !</string>
     <string name="calibrate_failed">La calibrazione fallito !</string>
     <string name="calibrate_restored">Calibrazione originale restaurata !</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -7,6 +7,7 @@
     <string name="calibrate_info">Druk op MENU voor calibratie</string>
     <string name="calibrate_title">Calibreer uw telefoon</string>
     <string name="calibrate_message">Plaats de zijkant van de telefoon die u wilt kalibreren op een vlak horizontaal oppervlak en druk op Calibreren</string>
+    <string name="calibrate_first_step">Nu uw apparaat 180 graden draaien en opnieuw kalibreren!</string>
     <string name="calibrate_saved">Nieuwe calibratie opgeslagen !</string>
     <string name="calibrate_failed">Calibratie mislukt !</string>
     <string name="calibrate_restored">Oorspronkelijke calibratie hersteld !</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -7,6 +7,7 @@
     <string name="calibrate_info">Clique em MENU para calibrar...</string>
     <string name="calibrate_title">Calibrar o telemóvel</string>
     <string name="calibrate_message">Coloque o lado do telefone que deseja calibrar numa superfície plana horizontal e clique em Calibrar.</string>
+    <string name="calibrate_first_step">Agora rodar o seu dispositivo 180 graus e calibrar novamente!</string>
     <string name="calibrate_saved">A calibragem foi guardada!</string>
     <string name="calibrate_failed">A calibragem falhou!</string>
     <string name="calibrate_restored">Aplicada a calibragem de origem!</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -9,6 +9,7 @@
     <string name="calibrate_message">将手机调整至水平位置，点击校准按钮。
 
 或重置校准手机的所有边。</string>
+    <string name="calibrate_first_step">现在转动设备180度并再次校准!</string>
     <string name="calibrate_saved">定制校准已保存！</string>
     <string name="calibrate_failed">校准失败！</string>
     <string name="calibrate_restored">初始校准已恢复！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="calibrate_info">press MENU to calibrate...</string>
     <string name="calibrate_title">Calibrate your phone</string>
     <string name="calibrate_message">Put any side (including the back) of your Android device on a flat horizontal surface and press the Calibrate button.\n\nOr reset the calibration for all the phone sides.</string>
+    <string name="calibrate_first_step">Now turn Your device 180 degrees and calibrate again !</string>
     <string name="calibrate_saved">Custom calibration saved !</string>
     <string name="calibrate_failed">Calibration failed !</string>
     <string name="calibrate_restored">Original calibration restored !</string>


### PR DESCRIPTION
The presented modification allows the user to enter 2 values for the calibration. The correction value is calculated from the average of both values.

The existing user interface has not been changed. Only a new feedback after the first calibration has been introduced of the possibility of a second input. The translations of the new text (except for German) are from DeepL and Google (and are possibly will need some revision).

With this change it is possible to calibrate the device also on inclined, not horizontal planes.
