### PR TITLE
Config option to swap 'display' view with 'locking' view

### DIFF
--- a/app/src/main/java/org/woheller69/level/painter/LevelPainter.java
+++ b/app/src/main/java/org/woheller69/level/painter/LevelPainter.java
@@ -180,6 +180,7 @@ public class LevelPainter implements Runnable {
      */
     private boolean showAngle;
     private boolean lockEnabled;
+    private boolean swapViewsEnabled;
     private boolean locked;
     private long frameRate;
 
@@ -285,6 +286,7 @@ public class LevelPainter implements Runnable {
         this.locked = false;
         Level.getProvider().setLocked(this.locked);
         this.lockEnabled = PreferenceHelper.getOrientationLocked();
+        this.swapViewsEnabled = PreferenceHelper.getSwapViewsEnabled();
         this.orientation = Orientation.TOP;
         this.wait = true;
         this.initialized = false;
@@ -662,26 +664,46 @@ public class LevelPainter implements Runnable {
                 maxBubble = (int) (maxLevelY - bubbleHeight * BUBBLE_CROPPING);
                 minBubble = maxBubble - bubbleHeight;
 
+                // prepare Top and Bottom positions for 'display' and 'lock' here
+                // as they might get swapped
+                int displayRectTop = sensorY - displayGap - 2 * displayPadding - lcdHeight - infoHeight / 2;
+                int displayRectBottom = sensorY - displayGap - infoHeight / 2;
+
+                int lockRectTop = middleY - height / 2 + displayGap;
+                int lockRectBottom = middleY - height / 2 + displayGap + 2 * displayPadding + lockHeight;
+
+                if (swapViewsEnabled) {
+                    // swap 'display' with 'lock' position
+                    int topSwap = lockRectTop;
+                    int bottomSwap = lockRectBottom;
+                    lockRectTop = displayRectTop;
+                    lockRectBottom = displayRectBottom;
+                    displayRectTop = topSwap;
+                    displayRectBottom = bottomSwap;
+                }
+
                 // display
+                int displayRectRight = middleX + lcdWidth / 2 + displayPadding + arrowWidth / 2;
                 if (orientation == Orientation.LANDING) {
                     displayRect.set(
                             middleX - lcdWidth / 2 - arrowWidth / 2 - displayPadding,
-                            sensorY - displayGap - 2 * displayPadding - lcdHeight - infoHeight / 2,
-                            middleX + lcdWidth / 2 + displayPadding + arrowWidth / 2,
-                            sensorY - displayGap - infoHeight / 2);
+                            displayRectTop,
+                            displayRectRight,
+                            displayRectBottom);
                 } else {
                     displayRect.set(
                             middleX - arrowWidth / 2 - lcdWidth / 2 - displayPadding,
-                            sensorY - displayGap - 2 * displayPadding - lcdHeight - infoHeight / 2,
-                            middleX + lcdWidth / 2 + displayPadding + arrowWidth / 2,
-                            sensorY - displayGap - infoHeight / 2);
+                            displayRectTop,
+                            displayRectRight,
+                            displayRectBottom);
                 }
+
                 // lock
                 lockRect.set(
                         middleX - lockWidth / 2 - displayPadding,
-                        middleY - height / 2 + displayGap,
+                        lockRectTop,
                         middleX + lockWidth / 2 + displayPadding,
-                        middleY - height / 2 + displayGap + 2 * displayPadding + lockHeight);
+                        lockRectBottom);
 
                 // marker
                 halfMarkerGap = (int) (levelWidth * MARKER_GAP / 2);

--- a/app/src/main/java/org/woheller69/level/util/PrefKeys.java
+++ b/app/src/main/java/org/woheller69/level/util/PrefKeys.java
@@ -17,4 +17,6 @@ public class PrefKeys {
     public static final int PREF_VISCOSITY_HIGH = R.string.prefKey_viscosity_high;
 
     public static final int PREF_ENABLE_SOUND = R.string.prefKey_enableSound;
+
+    public static final int PREF_SWAP_VIEWS = R.string.prefKey_swapViews;
 }

--- a/app/src/main/java/org/woheller69/level/util/PreferenceHelper.java
+++ b/app/src/main/java/org/woheller69/level/util/PreferenceHelper.java
@@ -108,4 +108,8 @@ public class PreferenceHelper {
     public static boolean getSoundEnabled() {
         return getHelperBoolean(PrefKeys.PREF_ENABLE_SOUND, false);
     }
+
+    public static boolean getSwapViewsEnabled() {
+        return getHelperBoolean(PrefKeys.PREF_SWAP_VIEWS, false);
+    }
 }

--- a/app/src/main/res/values/pref_keys.xml
+++ b/app/src/main/res/values/pref_keys.xml
@@ -16,4 +16,6 @@
 
     <string name="prefKey_enableSound" translatable="false">pref_enableSound</string>
 
+    <string name="prefKey_swapViews" translatable="false">pref_swapViews</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <string name="preference_lock">Locking</string>
     <string name="preference_lock_summary">Allow level orientation locking</string>
     <string name="preference_viscosity">Viscosity</string>
+    <string name="preference_swapViews">Swap Views</string>
+    <string name="preference_swapViews_summary">Swap position for \'display\' view with \'locking\' view</string>
     <string name="angle">Angle</string>
     <string name="lock_info">tap to lock level orientation</string>
     <string name="inclination">Inclination</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -44,6 +44,12 @@
             android:title="@string/preference_sound"
             app:iconSpaceReserved="false" />
 
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="@string/prefKey_swapViews"
+            android:summary="@string/preference_swapViews_summary"
+            android:title="@string/preference_swapViews"
+            app:iconSpaceReserved="false" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
I found myself in a situation in which the whole screen of my phone could not be seen and thus the 'display' view was hidden.

This patch introduces a config option to swap the position for 'display' with 'locking'.